### PR TITLE
Improve authors documentation

### DIFF
--- a/source/includes/v2-protocol/_package-entity.md
+++ b/source/includes/v2-protocol/_package-entity.md
@@ -19,7 +19,7 @@ Element                       | Description
 `<id>`, text content          | URL to [get metadata about a single package](#endpoint-get-a-single-package)
 `<content>`, `src` attribute  | URL to download the .nupkg
 `<summary>`, text content     | Summary **only when Summary is defined**
-`<author>`, `<name>` children | Authors, split into multiple values
+`<author>`, `<name>` children | Authors string
 
 The following properties vary from one server implementation to the next.
 


### PR DESCRIPTION
Neither NuGetGallery nor NuGet.Server split the authors string when creating the `author` element in the package entity. Instead, they output the full authors string.

<details>
<summary>Example request from nuget.org...</summary>

See: https://www.nuget.org/api/v2/Packages(id='hangfire.postgresql',version='1.8.4')

```xml
<?xml version="1.0" encoding="utf-8"?>
<entry xml:base="https://www.nuget.org/api/v2" ...>
    <id>https://www.nuget.org/api/v2/Packages(Id='Hangfire.PostgreSql',Version='1.8.4')</id>

    ...

    <author>
        <name>Frank Hommers and others (Burhan Irmikci (barhun), Zachary Sims(zsims), kgamecarter, Stafford Williams (staff0rd), briangweber, Viktor Svyatokha (ahydrax), Christopher Dresel (Dresel), Vytautas Kasparavičius (vytautask), Vincent Vrijburg, David Roth (davidroth).</name>
    </author>

    ...

    <m:properties>
        <d:Id>Hangfire.PostgreSql</d:Id>
        <d:Version>1.8.4</d:Version>
        <d:NormalizedVersion>1.8.4</d:NormalizedVersion>
        <d:Authors>Frank Hommers and others (Burhan Irmikci (barhun), Zachary Sims(zsims), kgamecarter, Stafford Williams (staff0rd), briangweber, Viktor Svyatokha (ahydrax), Christopher Dresel (Dresel), Vytautas Kasparavičius (vytautask), Vincent Vrijburg, David Roth (davidroth).</d:Authors>

        ...
    </m:properties>
</entry>
```
</details>

Implementations:
* [NuGetGallery](https://github.com/NuGet/NuGetGallery/blob/a929ae1b53a5bfdead4475e33819032b8e3f97a6/src/NuGetGallery/OData/Serializers/V2FeedPackageAnnotationStrategy.cs#L37)
* [NuGet.Server](https://github.com/NuGet/NuGet.Server/blob/3d8f707e725d428d55694f28d423534849c2576c/src/NuGet.Server.V2/OData/Serializers/NuGetEntityTypeSerializer.cs#L46)
